### PR TITLE
New Widget Types

### DIFF
--- a/app/views/widgets/geckometer.xml.erb
+++ b/app/views/widgets/geckometer.xml.erb
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<root>
+  <item><%= @data[:value] %></item>
+  <min>
+    <value><%= @data[:min][:value] rescue "" %></value>
+    <text><%= @data[:min][:label] rescue "" %></text>
+  </min>
+  <max>
+    <value><%= @data[:max][:value] rescue "" %></value>
+    <text><%= @data[:max][:label] rescue "" %></text>
+  </max>
+</root>

--- a/app/views/widgets/number_and_secondary.xml.erb
+++ b/app/views/widgets/number_and_secondary.xml.erb
@@ -2,7 +2,7 @@
 <root>
   <item>
     <value><%= @data[:value] %></value>
-    <text></text>
+    <text><%= @data[:display] %></text>
   </item>
   <item>
     <value><%= @data[:previous] %></value>

--- a/app/views/widgets/rag.xml.erb
+++ b/app/views/widgets/rag.xml.erb
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<root>
+  <item>
+    <value><%= @data[:red][:value] rescue "" %></value>
+    <text><%= @data[:red][:label] rescue "" %></text>
+  </item>
+  <item>
+    <value><%= @data[:amber][:value] rescue "" %></value>
+    <text><%= @data[:amber][:label] rescue "" %></text>
+  </item>
+  <item>
+    <value><%= @data[:green][:value] rescue "" %></value>
+    <text><%= @data[:green][:label] rescue "" %></text>
+  </item>
+</root>

--- a/app/views/widgets/text.xml.erb
+++ b/app/views/widgets/text.xml.erb
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<root>
+  <% @data.each do |panel| %>
+  <item>
+    <text><![CDATA[<%= panel[:text] %>]]></text>
+    <type><%=
+      case panel[:type]
+        when :alert then 1
+        when :info then 2
+        else 0
+      end
+    %></type>
+  </item>
+  <% end %>
+</root>

--- a/test/dummy/app/widgets/test_geckometer.rb
+++ b/test/dummy/app/widgets/test_geckometer.rb
@@ -1,0 +1,12 @@
+widget :geckometer do
+  key "x"
+  type "geckometer"
+  data do
+    {
+      :value => 23,
+      :min => { :value => 10, :label => "Min visitors" },
+      :max => { :value => 30, :label => "Max visitors" }
+    }
+  end
+end
+

--- a/test/dummy/app/widgets/test_number_and_secondary_with_text.rb
+++ b/test/dummy/app/widgets/test_number_and_secondary_with_text.rb
@@ -1,0 +1,11 @@
+widget :number_and_secondary_with_text do
+  key "x"
+  type "number_and_secondary"
+  data do
+    {
+      :value => 1,
+      :display => 'Display Me',
+      :previous => 2
+    }
+  end
+end

--- a/test/dummy/app/widgets/test_rag.rb
+++ b/test/dummy/app/widgets/test_rag.rb
@@ -1,0 +1,11 @@
+widget :rag do
+  key "x"
+  type "rag"
+  data do
+    {
+      :red => { :value => 5, :label => "Five" },
+      :amber => { :value => 2, :label => "Two" },
+      :green => { :value => 1, :label => "One" }
+    }
+  end
+end

--- a/test/dummy/app/widgets/test_rag_with_empty_values.rb
+++ b/test/dummy/app/widgets/test_rag_with_empty_values.rb
@@ -1,0 +1,9 @@
+widget :rag_with_empty_values do
+  key "x"
+  type "rag"
+  data do
+    {
+      :amber => { :value => 2, :label => "Two" }
+    }
+  end
+end

--- a/test/dummy/app/widgets/test_text.rb
+++ b/test/dummy/app/widgets/test_text.rb
@@ -1,0 +1,9 @@
+widget :text do
+  key "x"
+  type "text"
+  data do
+    [
+      { :text => "First panel text" }
+    ]
+  end
+end

--- a/test/dummy/app/widgets/test_text_with_multiple_panels.rb
+++ b/test/dummy/app/widgets/test_text_with_multiple_panels.rb
@@ -1,0 +1,11 @@
+widget :text_with_multiple_panels do
+  key "x"
+  type "text"
+  data do
+    [
+      { :text => "First panel text" },
+      { :text => "Second panel text" },
+      { :text => "Third panel text" }
+    ]
+  end
+end

--- a/test/dummy/app/widgets/test_text_with_multiple_panels_and_types.rb
+++ b/test/dummy/app/widgets/test_text_with_multiple_panels_and_types.rb
@@ -1,0 +1,11 @@
+widget :text_with_multiple_panels_and_types do
+  key "x"
+  type "text"
+  data do
+    [
+      { :text => "First panel text", :type => :info },
+      { :text => "Second panel text", :type => :alert },
+      { :text => "Third panel text" }
+    ]
+  end
+end

--- a/test/functional/widgets_test.rb
+++ b/test/functional/widgets_test.rb
@@ -126,4 +126,126 @@ xml =<<EOF
 EOF
     assert_equal xml, response.body
   end
+
+  test "rag" do
+    get :show, :id => "rag", :key => "x"
+xml =<<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<root>
+  <item>
+    <value>5</value>
+    <text>Five</text>
+  </item>
+  <item>
+    <value>2</value>
+    <text>Two</text>
+  </item>
+  <item>
+    <value>1</value>
+    <text>One</text>
+  </item>
+</root>
+EOF
+    assert_equal xml, response.body
+  end
+
+  test "rag with empty values" do
+    get :show, :id => "rag_with_empty_values", :key => "x"
+xml =<<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<root>
+  <item>
+    <value></value>
+    <text></text>
+  </item>
+  <item>
+    <value>2</value>
+    <text>Two</text>
+  </item>
+  <item>
+    <value></value>
+    <text></text>
+  </item>
+</root>
+EOF
+    assert_equal xml, response.body
+  end
+
+  test "text" do
+    get :show, :id => "text", :key => "x"
+xml =<<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<root>
+  <item>
+    <text><![CDATA[First panel text]]></text>
+    <type>0</type>
+  </item>
+</root>
+EOF
+    assert_equal xml, response.body
+  end
+
+  test "text with multiple panels" do
+    get :show, :id => "text_with_multiple_panels", :key => "x"
+xml =<<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<root>
+  <item>
+    <text><![CDATA[First panel text]]></text>
+    <type>0</type>
+  </item>
+  <item>
+    <text><![CDATA[Second panel text]]></text>
+    <type>0</type>
+  </item>
+  <item>
+    <text><![CDATA[Third panel text]]></text>
+    <type>0</type>
+  </item>
+</root>
+EOF
+    assert_equal xml, response.body
+  end
+
+  test "text with multiple panels and types" do
+    get :show, :id => "text_with_multiple_panels_and_types", :key => "x"
+xml =<<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<root>
+  <item>
+    <text><![CDATA[First panel text]]></text>
+    <type>2</type>
+  </item>
+  <item>
+    <text><![CDATA[Second panel text]]></text>
+    <type>1</type>
+  </item>
+  <item>
+    <text><![CDATA[Third panel text]]></text>
+    <type>0</type>
+  </item>
+</root>
+EOF
+    assert_equal xml, response.body
+  end
+
+  test "geckometer" do
+    get :show, :id => "geckometer", :key => "x"
+xml =<<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<root>
+  <item>23</item>
+  <min>
+    <value>10</value>
+    <text>Min visitors</text>
+  </min>
+  <max>
+    <value>30</value>
+    <text>Max visitors</text>
+  </max>
+</root>
+EOF
+    assert_equal xml, response.body
+  end
+
 end

--- a/test/functional/widgets_test.rb
+++ b/test/functional/widgets_test.rb
@@ -59,6 +59,24 @@ EOF
     assert_equal xml, response.body
   end
 
+  test "number and secondary widget with custom display text" do
+    get :show, :id => "number_and_secondary_with_text", :key => "x"
+xml =<<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<root>
+  <item>
+    <value>1</value>
+    <text>Display Me</text>
+  </item>
+  <item>
+    <value>2</value>
+    <text></text>
+  </item>
+</root>
+EOF
+    assert_equal xml, response.body
+  end
+
   test "line widget" do
     get :show, :id => "test4", :token => "987654321"
 xml =<<EOF


### PR DESCRIPTION
Hey there,

I've added the formats for the other widget types that Geckoboard allows (text, rag and geckometer), plus allowing custom display text on the number_and_secondary type.

One other tweak: I added a .gitignore file to the test/dummy/db directory; without it this directory doesn't get created on an initial repo clone, and the `rake test` expects it to be there to run (not that anything ever gets written there).

Cheers,

Tim.
