### PR TITLE
Allow HTML in Text Widgets

### DIFF
--- a/app/views/widgets/text.xml.erb
+++ b/app/views/widgets/text.xml.erb
@@ -2,7 +2,11 @@
 <root>
   <% @data.each do |panel| %>
   <item>
-    <text><![CDATA[<%= panel[:text] %>]]></text>
+    <% if !panel[:html].nil? %>
+      <text><![CDATA[<%=raw panel[:html] %>]]></text>
+    <% else %>
+      <text><![CDATA[<%= panel[:text] %>]]></text>
+    <% end %>
     <type><%=
       case panel[:type]
         when :alert then 1


### PR DESCRIPTION
Geckoboard allows widgets to use certain HTML elements in the text output. If you want to use HTML markup in text widgets set it as the :html hash element instead of :text and it won't be escaped in the template
